### PR TITLE
hilt 세팅 / Client를 주입받아 사용하도록 변경

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("com.google.gms.google-services")
+    kotlin("kapt")
+    id("com.google.dagger.hilt.android")
 }
 
 android {
@@ -43,4 +45,11 @@ dependencies {
     implementation(project(":domain"))
     implementation(project(":data"))
 
+    implementation("com.google.dagger:hilt-android:2.45")
+    kapt("com.google.dagger:hilt-android-compiler:2.45")
+
+}
+
+kapt {
+    correctErrorTypes = true
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
+        android:name=".App"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/pl/statusboard/App.kt
+++ b/app/src/main/java/com/pl/statusboard/App.kt
@@ -1,0 +1,9 @@
+package com.pl.statusboard
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class App: Application() {
+
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,4 +10,5 @@ plugins {
     id("org.jetbrains.kotlin.android") version "1.8.0" apply false
     id("org.jetbrains.kotlin.jvm") version "1.8.0" apply false
     id("org.jetbrains.kotlin.plugin.serialization") version "1.8.0"
+    id("com.google.dagger.hilt.android") version "2.44" apply false
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -5,6 +5,8 @@ import java.util.Properties
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
+    id("kotlin-kapt")
+    id("dagger.hilt.android.plugin")
 }
 
 val properties = Properties()
@@ -63,4 +65,7 @@ dependencies {
 
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0")
     implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
+
+    implementation("com.google.dagger:hilt-android:2.45")
+    kapt("com.google.dagger:hilt-android-compiler:2.45")
 }

--- a/data/src/main/java/com/pl/data/ClientModule.kt
+++ b/data/src/main/java/com/pl/data/ClientModule.kt
@@ -1,0 +1,24 @@
+package com.pl.data
+
+import com.pl.domain.StatusBoardClient
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import io.ktor.client.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+
+@Module
+@InstallIn(SingletonComponent::class)
+class ClientModule {
+
+    @Provides
+    fun provideClient(): StatusBoardClient {
+        return  StatusBoardClientImpl()
+    }
+
+}

--- a/data/src/main/java/com/pl/data/StatusBoardClientImpl.kt
+++ b/data/src/main/java/com/pl/data/StatusBoardClientImpl.kt
@@ -1,5 +1,6 @@
 package com.pl.data
 
+import com.pl.domain.StatusBoardClient
 import com.pl.domain.WebHookMessage
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
@@ -8,16 +9,15 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 
-class StatusBoardClient {
+class StatusBoardClientImpl: StatusBoardClient {
 
     private val client = HttpClient(CIO) {
         install(ContentNegotiation) {
             json()
         }
-
     }
 
-    suspend fun postWebHookMessage(message: WebHookMessage) {
+    override suspend fun postWebHookMessage(message: WebHookMessage) {
         client
             .post(BuildConfig.webhookUrl) {
                 header(HttpHeaders.ContentType, ContentType.Application.Json)

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -13,4 +13,5 @@ dependencies {
     val ktorVersion = "2.2.4"
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0")
     implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
+    implementation("javax.inject:javax.inject:1")
 }

--- a/domain/src/main/java/com/pl/domain/StatusBoardClient.kt
+++ b/domain/src/main/java/com/pl/domain/StatusBoardClient.kt
@@ -1,0 +1,5 @@
+package com.pl.domain
+
+interface StatusBoardClient {
+    suspend fun postWebHookMessage(message: WebHookMessage)
+}

--- a/domain/src/main/java/com/pl/domain/usecase/PostWebhookUseCase.kt
+++ b/domain/src/main/java/com/pl/domain/usecase/PostWebhookUseCase.kt
@@ -1,0 +1,14 @@
+package com.pl.domain.usecase
+
+import com.pl.domain.StatusBoardClient
+import com.pl.domain.WebHookMessage
+import javax.inject.Inject
+
+class PostWebhookUseCase @Inject constructor(
+    private val statusBoardClient: StatusBoardClient
+) {
+
+    suspend operator fun invoke(message: WebHookMessage) {
+        statusBoardClient.postWebHookMessage(message)
+    }
+}

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -3,6 +3,8 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
+    id("kotlin-kapt")
+    id("dagger.hilt.android.plugin")
 }
 
 android {
@@ -48,4 +50,7 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+
+    implementation("com.google.dagger:hilt-android:2.45")
+    kapt("com.google.dagger:hilt-android-compiler:2.45")
 }

--- a/presentation/src/main/java/com/pl/presentation/MainActivity.kt
+++ b/presentation/src/main/java/com/pl/presentation/MainActivity.kt
@@ -3,7 +3,9 @@ package com.pl.presentation
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import com.pl.presentation.databinding.ActivityMainBinding
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
## 개요
- hilt 기본 세팅
- Data Layer에서 Domain Layer로 Client를 주입하여 Presentation Layer는 Domain Layer의 UseCase를 사용하는 방식으로 Http 통신을 구현
  - Presentation <-> Data Layer 간 의존성 분리  