### PR TITLE
원격으로 상태를 변경하면 웹훅 메시지가 전송되지 않던 이슈 해결

### DIFF
--- a/domain/src/main/java/com/pl/domain/usecase/CheckDuplicatedMemberStateUseCase.kt
+++ b/domain/src/main/java/com/pl/domain/usecase/CheckDuplicatedMemberStateUseCase.kt
@@ -1,0 +1,14 @@
+package com.pl.domain.usecase
+
+import com.pl.domain.MemberState
+import javax.inject.Inject
+
+class CheckDuplicatedMemberStateUseCase @Inject constructor(
+    private val getMemberStateFromCacheUseCase: GetMemberStateFromCacheUseCase
+) {
+    suspend operator fun invoke(memberState: MemberState): Boolean {
+
+        val memberStateFromCache = getMemberStateFromCacheUseCase(memberState.name)
+        return memberStateFromCache == memberState.status.text
+    }
+}


### PR DESCRIPTION
## 개요
- 원격으로 상태를 변경하면 웹훅 메시지가 전송되지 않던 이슈 해결
- 각 UseCase의 역할을 조금 더 분리